### PR TITLE
Add proposal for setup improvement

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,8 @@ plugins {
 
 application {
     // NOTE: In case you choose a different main class, make sure to update this path
-    mainClass = "george.backend.hiring.KotlinApplicationKt"
+    mainClass = "KotlinApplicationKt"
+    // mainClass = "JavaApplication"
 }
 
 tasks.jar {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,20 @@
 plugins {
     java
+    application
     kotlin("jvm") version "1.9.23"
+}
+
+application {
+    // NOTE: In case you choose a different main class, make sure to update this path
+    mainClass = "george.backend.hiring.KotlinApplicationKt"
+}
+
+tasks.jar {
+    manifest {
+        attributes["Main-Class"] = application.mainClass
+    }
+
+    from(configurations.runtimeClasspath.get().filter { it.name.endsWith("jar") }.map { zipTree(it) })
 }
 
 repositories {

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+## Wordcount
+
+To run the application...

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,8 @@ In case the requirements are ambiguous, please write down your assumptions into 
 file.
 Please always create a section for each iteration and put your assumptions under this section.
 This helps us to follow certain design decisions in your code which you came up with based on your assumptions.
-Don't hesitate to also explain assumptions using comments in your source code.
+If you need to explain design decisions that don't make any assumptions about the program requirements, 
+don't hesitate to use comments in your source code.
 
 ### Evaluation
 
@@ -85,10 +86,10 @@ If we do not continue the recruiting process with you, we will send you a detail
 
 ### Requirements
 
-Please use Java 21 or Kotlin as a programming language, the project is already setup to support both.
+Please use Kotlin or Java 21 as a programming language, the project is already setup to support both.
 No Frameworks are allowed for this exercise.
 No other libraries than JUnit and the Kotlin Standard Library must be used.
-The project is set up to be used with Maven and Gradle using their respective wrappers.
+The project is set up to be used with Gradle and Maven using their respective wrappers.
 Currently, JUnit 5 as well as Kotlin are configured in the `pom.xml` as well as in the `build.gradle.kts`.
 We don’t allow any mocking library.
 In case you see the need for mocking, please hand-roll your mocks.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # George Backend Chapter - Coding Challenge
 
-Congratulations. You made it to our next recruiting stage which is a coding challenge.
+Congratulations! You made it to our next recruiting stage which is a coding challenge.
 In this stage you have to show practical skills in the things which we discussed in the previous recruiting stage:
 
 - Object-Oriented Programming
@@ -28,7 +28,7 @@ You will find all requirements split into 9 iterations.
 The goal of this exercise is __not__ to finish as many iterations as possible.
 We will evaluate your solution based on __quality over quantity__.
 
-Please focus on code quality by applying
+Please focus on code quality by applying:
 
 - Object-Oriented Programming
 - Refactoring
@@ -53,7 +53,7 @@ We always put ourselves into our reviewers position to improve their life when r
   pattern: `<firstname>_<lastname>_session_<session-nr>_iteration_<iteration-nr>_<pairing-partner-name>`
     - The `<pairing-partner-name>` is the name of the team member you pair in this iteration
 - Your first iteration must branch off `main`
-- Your branches won't be merged back to master
+- Your branches won't be merged back to `main`
 - Make sure every new branch is based on the previous branch
 
 ### Assumptions
@@ -62,6 +62,7 @@ In case the requirements are ambiguous, please write down your assumptions into 
 file.
 Please always create a section for each iteration and put your assumptions under this section.
 This helps us to follow certain design decisions in your code which you came up with based on your assumptions.
+Don't hesitate to also explain assumptions using comments in your source code.
 
 ### Evaluation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -102,7 +102,8 @@ In case you see the need for mocking, please hand-roll your mocks.
 3. Push this branch to the repository
 4. Run `./mvnw clean verify` or `./gradlew clean check` via your terminal
 5. Open the project in your IDE of choice
-6. Create a dummy unit test and run it
-7. Read the requirements from the _Requirements_ section  
+6. Update `mainClass` in Gradle or Maven config to point to either Kotlin or Java main method depending on your choice of language
+7. Create a dummy unit test and run it
+8. Read the requirements from the _Requirements_ section  
    Please only read one iteration at a time, starting with iteration 1
-8. Please think about how you will approach this problem in code for a few minutes before you start coding
+9. Please think about how you will approach this problem in code for a few minutes before you start coding

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,16 @@
                     </descriptorRefs>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -138,16 +138,6 @@
                     </descriptorRefs>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-jar</id>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <junit-jupiter.version>5.10.2</junit-jupiter.version>
 
         <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
+        <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -111,6 +112,31 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven-assembly-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <!-- NOTE: In case you choose a different main class, make sure to update this path -->
+                            <mainClass>JavaApplication</mainClass>
+                            <!-- <mainClass>KotlinApplicationKt</mainClass> -->
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/JavaApplication.java
+++ b/src/main/java/JavaApplication.java
@@ -1,2 +1,0 @@
-public class JavaApplication {
-}

--- a/src/main/java/JavaApplication.java
+++ b/src/main/java/JavaApplication.java
@@ -1,0 +1,4 @@
+
+public class JavaApplication {
+
+}

--- a/src/main/java/george/backend/hiring/JavaApplication.java
+++ b/src/main/java/george/backend/hiring/JavaApplication.java
@@ -1,9 +1,0 @@
-package george.backend.hiring;
-
-public class JavaApplication {
-
-    public static void main(String[] args) {
-        System.out.println("Hello, World!");
-    }
-
-}

--- a/src/main/java/george/backend/hiring/JavaApplication.java
+++ b/src/main/java/george/backend/hiring/JavaApplication.java
@@ -1,0 +1,9 @@
+package george.backend.hiring;
+
+public class JavaApplication {
+
+    public static void main(String[] args) {
+        System.out.println("Hello, World!");
+    }
+
+}

--- a/src/main/kotlin/KotlinApplication.kt
+++ b/src/main/kotlin/KotlinApplication.kt
@@ -1,2 +1,0 @@
-class KotlinApplication {
-}

--- a/src/main/kotlin/george/backend/hiring/KotlinApplication.kt
+++ b/src/main/kotlin/george/backend/hiring/KotlinApplication.kt
@@ -1,0 +1,5 @@
+package george.backend.hiring
+
+fun main(args: Array<String>) {
+    println("Hello, World!")
+}

--- a/src/main/kotlin/george/backend/hiring/KotlinApplication.kt
+++ b/src/main/kotlin/george/backend/hiring/KotlinApplication.kt
@@ -1,5 +1,0 @@
-package george.backend.hiring
-
-fun main(args: Array<String>) {
-    println("Hello, World!")
-}


### PR DESCRIPTION
This PR addresses an error that many candidates faced when trying to run the application as `.jar`.

Before:
```shell
$ ./gradlew :jar && java -jar build/libs/wordcount.jar

no main manifest attribute, in build/libs/wordcount.jar
```

Now:
```shell
$ ./gradlew :jar && java -jar build/libs/wordcount.jar

Hello, World!
```

---
ℹ️ I've tried these 4 variations using Gradle (I've ignored Maven for now):
1. Run Kotlin application from IDE and read file from resources.
2. Run Java application from IDE and read file from resources.
3. Run Kotlin application from packaged `.jar` and read file from resources.
4. Run Kotlin application from packaged `.jar` and read file from resources.